### PR TITLE
SSA-8/Fix_gradle_issues_and_other_thngs

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,10 +26,7 @@ android {
         }
     }
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
+    dataBinding.enabled = true
 
 }
 

--- a/app/src/main/res/layout/fragment_planet_detail.xml
+++ b/app/src/main/res/layout/fragment_planet_detail.xml
@@ -14,7 +14,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:minHeight="200dp"
-            tools:src="@mipmap/ic_launcher"
+            android:src="@mipmap/ic_launcher"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_planets_list.xml
+++ b/app/src/main/res/layout/fragment_planets_list.xml
@@ -5,6 +5,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/refresh_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".view.PlanetsListFragment">

--- a/app/src/main/res/layout/item_planet.xml
+++ b/app/src/main/res/layout/item_planet.xml
@@ -12,7 +12,7 @@
         android:layout_width="100dp"
         android:layout_height="100dp"
         android:contentDescription="@string/planet_s_image"
-        tools:src="@mipmap/ic_launcher"
+        android:src="@mipmap/ic_launcher"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toStartOf="@id/planet_name"


### PR DESCRIPTION
Addition of dataBinding = true in gradle in order to make the fragment_planets_list layout can work.
Layouts which requires image sources, now they use android:src instead of tools:src in order to see the test image in the emulation.
The extra file misc.xml is auto-generated after dataBinding = true was added